### PR TITLE
fix: add json formatting formatting and lang discrimination

### DIFF
--- a/cmd/wasm/functions.go
+++ b/cmd/wasm/functions.go
@@ -181,16 +181,25 @@ type IncompleteOverlayErrorMessage struct {
 }
 
 func applyOverlayJSONPathIncomplete(result []*yaml.Node, node *yaml.Node) (string, error) {
-	yamlResult, err := yaml.Marshal(result)
+	var data interface{}
+	if len(result) == 1 {
+		data = result[0]
+	} else {
+		data = result
+	}
+
+	yamlResult, err := yaml.Marshal(data)
 	if err != nil {
 		return "", err
 	}
+
 	out, err := json.Marshal(IncompleteOverlayErrorMessage{
 		Type:   "incomplete",
 		Line:   node.Line,
 		Col:    node.Column,
 		Result: string(yamlResult),
 	})
+
 	return string(out), err
 }
 

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -28,6 +28,7 @@ export interface EditorComponentProps {
     value: string | undefined,
     ev: editor.IModelContentChangedEvent,
   ) => void;
+  language: DocumentLanguage;
 }
 
 const minLoadingTime = 150;
@@ -216,7 +217,7 @@ export function Editor(props: EditorComponentProps) {
         originalModelPath={encodedTitle + "/original"}
         modifiedModelPath={encodedTitle + "/modified"}
         theme={"vscode-dark"}
-        language="yaml"
+        language={props.language}
         options={options}
       />
     </div>

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,6 +1,24 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function guessDocumentLanguage(content: string): DocumentLanguage {
+  try {
+    JSON.parse(content);
+    return "json";
+  } catch {
+    return "yaml";
+  }
+}
+
+export function formatDocument(doc: string, indentWidth: number = 2): string {
+  const docLang = guessDocumentLanguage(doc);
+
+  if (docLang === "json")
+    return JSON.stringify(JSON.parse(doc), null, indentWidth);
+
+  return doc;
 }

--- a/web/src/types.d.ts
+++ b/web/src/types.d.ts
@@ -7,3 +7,5 @@ declare class Go {
   mem: DataView;
   run(instance: WebAssembly.Instance): Promise<void>;
 }
+
+declare type DocumentLanguage = "json" | "yaml";


### PR DESCRIPTION
This PR does 3 things:
1. formats the output column to JSON if the input has JSON pasted into it

2. in `jsonpathexplorer` mode - the output will no longer be wrapped in a yaml array. This was resulting in weird scenarios where JSON would be wrapped in a yaml array, and thus not formatted. For example:
```
- {"openapi":"3.0.1", ...}
```
(The `-` prefix denotes a yaml array)

3. the editor panes (original, and original+overlay) should update their language when the content changes