### PR TITLE
change yaml library to go.yaml.in/yaml/v3

### DIFF
--- a/cmd/wasm/functions.go
+++ b/cmd/wasm/functions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
 	"github.com/speakeasy-api/jsonpath/pkg/overlay"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"reflect"
 	"syscall/js"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.22
 require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.9.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"os"
 	"slices"
 	"strings"

--- a/pkg/jsonpath/filter.go
+++ b/pkg/jsonpath/filter.go
@@ -1,7 +1,7 @@
 package jsonpath
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"strconv"
 	"strings"
 )

--- a/pkg/jsonpath/jsonpath.go
+++ b/pkg/jsonpath/jsonpath.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func NewPath(input string, opts ...config.Option) (*JSONPath, error) {

--- a/pkg/jsonpath/segment.go
+++ b/pkg/jsonpath/segment.go
@@ -1,7 +1,7 @@
 package jsonpath
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"strings"
 )
 

--- a/pkg/jsonpath/yaml_eval.go
+++ b/pkg/jsonpath/yaml_eval.go
@@ -2,7 +2,7 @@ package jsonpath
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/pkg/jsonpath/yaml_eval_test.go
+++ b/pkg/jsonpath/yaml_eval_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestLiteralEquals(t *testing.T) {

--- a/pkg/jsonpath/yaml_query.go
+++ b/pkg/jsonpath/yaml_query.go
@@ -1,7 +1,7 @@
 package jsonpath
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Evaluator interface {

--- a/pkg/jsonpath/yaml_query_test.go
+++ b/pkg/jsonpath/yaml_query_test.go
@@ -3,7 +3,7 @@ package jsonpath
 import (
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"reflect"
 	"strings"
 	"testing"

--- a/pkg/overlay/apply.go
+++ b/pkg/overlay/apply.go
@@ -3,7 +3,7 @@ package overlay
 import (
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ApplyTo will take an overlay and apply its changes to the given YAML

--- a/pkg/overlay/apply_test.go
+++ b/pkg/overlay/apply_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"os"
 	"testing"
 )

--- a/pkg/overlay/compare.go
+++ b/pkg/overlay/compare.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Compare compares input specifications from two files and returns an overlay

--- a/pkg/overlay/compare_test.go
+++ b/pkg/overlay/compare_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/speakeasy-api/jsonpath/pkg/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"os"
 	"testing"
 )

--- a/pkg/overlay/parents.go
+++ b/pkg/overlay/parents.go
@@ -1,6 +1,6 @@
 package overlay
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 type parentIndex map[*yaml.Node]*yaml.Node
 

--- a/pkg/overlay/parse.go
+++ b/pkg/overlay/parse.go
@@ -2,7 +2,7 @@ package overlay
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"io"
 	"os"
 	"path/filepath"

--- a/pkg/overlay/schema.go
+++ b/pkg/overlay/schema.go
@@ -2,7 +2,7 @@ package overlay
 
 import (
 	"bytes"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Extensible provides a place for extensions to be added to components of the


### PR DESCRIPTION
Good day,

While working on one of my project I encountered a bug in [go-yaml](https://github.com/go-yaml/yaml/) and noticed that the library was archived on Apr 1, 2025 and is no longer maintained. Luckily the official YAML organization forked the project and is maintaining it under https://github.com/yaml/go-yaml/tree/v3.

This PR simply changed the library.

Thank you for reviewing this PR and let me know if anything should be changed!

P.S. `gopkg.in/yaml.v3` is included as an indirect dependency as `github.com/stretchr/testify/assert` depends on it.